### PR TITLE
Add missing libunwarp dependency

### DIFF
--- a/var/spack/repos/builtin/packages/py-py-spy/package.py
+++ b/var/spack/repos/builtin/packages/py-py-spy/package.py
@@ -17,4 +17,4 @@ class PyPySpy(PythonPackage):
     # Need to figure out how to manage these with Spack once we have a
     # CargoPackage base class.
     depends_on('rust', type='build')
-    depends_on('libunwarp')
+    depends_on('libunwind')

--- a/var/spack/repos/builtin/packages/py-py-spy/package.py
+++ b/var/spack/repos/builtin/packages/py-py-spy/package.py
@@ -17,3 +17,4 @@ class PyPySpy(PythonPackage):
     # Need to figure out how to manage these with Spack once we have a
     # CargoPackage base class.
     depends_on('rust', type='build')
+    depends_on('libunwarp')


### PR DESCRIPTION
py-py-spy fails to build with:
  = note: /bin/ld: cannot find -lunwind
          /bin/ld: cannot find -lunwind-ptrace
          /bin/ld: cannot find -lunwind-x86_64
          collect2: error: ld returned 1 exit status